### PR TITLE
Clarify lack of UV support in macOS Firefox

### DIFF
--- a/content/en/docs/reference/macos.md
+++ b/content/en/docs/reference/macos.md
@@ -40,7 +40,7 @@ To replace a legacy platform credential with a passkey, start a credential regis
 
 **Edge**: credentials created by Edge are currently [***single-device*** passkeys](/docs/reference/terms/#single-device-passkey), are not backed up to iCloud Keychain, and are ***not available outside of Edge***.
 
-**Firefox**: passkeys are not currently supported in Firefox on macOS. [***Single-device*** passkeys](/docs/reference/terms/#single-device-passkey) on a FIDO2 security key are supported.
+**Firefox**: passkeys are not currently supported in Firefox on macOS. [***Single-device*** passkeys](/docs/reference/terms/#single-device-passkey) on a FIDO2 security key are supported. [User verification]({{< ref "terms/#user-verification-uv" >}}) is not supported, though, which makes it impossible to implement WebAuthn-based passwordless authentication at this time.
 
 ## Resources
 


### PR DESCRIPTION
RP's shouldn't bother with trying to support macOS Firefox for passwordless auth. I added a callout to this fact to that section of the macOS reference doc.