### PR TITLE
Refine conditional UI code example

### DIFF
--- a/content/en/docs/use-cases/bootstrapping/index.md
+++ b/content/en/docs/use-cases/bootstrapping/index.md
@@ -44,8 +44,7 @@ To support the [autofill UI](/) for passkeys, make sure to:
 
       if (supported) {
         /**
-         * Replace `getAuthenticationOptions()` with logic that queries
-         * your server for options for `navigator.credentials.get()`
+         * Query your server for options for `navigator.credentials.get()`
          */
         try {
           const authOptions = await getAuthenticationOptions();

--- a/content/en/docs/use-cases/bootstrapping/index.md
+++ b/content/en/docs/use-cases/bootstrapping/index.md
@@ -33,18 +33,53 @@ To support the [autofill UI](/) for passkeys, make sure to:
 
 2. On page load, check to see if conditional mediation (autofill UI) is supported using an if statement, then call `navigator.credentials.get()` with `mediation: "conditional"` and `userVerification: "required"`.
 
-    ```js
-    if (PublicKeyCredential.isConditionalMediationSupported()) {
-      navigator.credentials.get({
-        mediation: "conditional",  
-        publicKey: {
-          challenge: ..., // server generated challenge value
-          rpId: ..., // RP's domain name
-          userVerification: "required", 
+```html
+<script>
+  (async () => {
+    if (
+      typeof window.PublicKeyCredential !== 'undefined'
+      && typeof window.PublicKeyCredential.isConditionalMediationSupported === 'function'
+    ) {
+      const supported = await PublicKeyCredential.isConditionalMediationSupported();
+
+      if (supported) {
+        /**
+         * Replace `getAuthenticationOptions()` with logic that queries
+         * your server for options for `navigator.credentials.get()`
+         */
+        try {
+          const authOptions = await getAuthenticationOptions();
+          /**
+           * This call to `navigator.credentials.get()` is "set and forget."
+           * The Promise will only resolve if the user successfully interacts
+           * with the browser's autofill UI to select a passkey.
+           */
+          const autoFillResponse = await navigator.credentials.get({
+            mediation: "conditional",
+            publicKey: {
+              ...authOptions,
+              /**
+               * `userVerification: "required"` MUST be set in the
+               * options returned from your server. Setting it here
+               * is for illustrative purposes only.
+               */
+              userVerification: "required",
+            }
+          });
+
+          /**
+           * Send the response to your server for verification.
+           * Authenticate the user if the response is valid.
+           */
+          await verifyAutoFillResponse(autoFillResponse);
+        } catch (err) {
+          console.error('Error with conditional UI:', err);
         }
-      });
+      }
     }
-    ```
+  })();
+</script>
+```
 
 This will cause the following to happen:
 


### PR DESCRIPTION
The conditional UI code sample didn't account for us settling on `PublicKeyCredential.isConditionalMediationSupported()` being an asynchronous method. This PR fixes that.

Fixes #98.

## Screenshots

![Screenshot 2022-11-30 at 5 09 58 PM](https://user-images.githubusercontent.com/5166470/204941668-0b86a9b9-7079-4929-aad4-c8318ee703e5.png)

