### PR TITLE
Change to device-bound passkey

### DIFF
--- a/content/en/device-support/_index.md
+++ b/content/en/device-support/_index.md
@@ -37,7 +37,7 @@ Passkeys created in **macOS** can be used on:
 - MacBooks using the same Apple ID and iCloud Keychain (synced automatically)
 - iPhones and iPads using the same Apple ID and iCloud Keychain (synced automatically)
 
-[Single-device passkeys](/docs/reference/terms/#single-device-passkeys) created in **Windows** can be used on:
+[Device-bound passkeys](/docs/reference/terms/#device-bound-passkey) created in **Windows** can be used on:
 
 - the same Windows device that created them
 
@@ -60,29 +60,16 @@ Passkeys created in **macOS** can be used on:
             <td><span class="fw-bold">Passkeys</span></td>
             <td class="text-center"><i class="bi bi-check-circle-fill text-success"></i><br>Android 9+
             </td>
-            <td class="text-center"><i class="bi bi-calendar-plus" title="Planned" alt="calendar icon"></i><br>Planned
+            <td class="text-center"><i class="bi bi-calendar-plus" title="Planned" alt="calendar icon"></i><br>Planned <sup>1</sup>
             </td>
             <td class="text-center"><i class="bi bi-check-circle-fill text-success"></i><br>iOS 16+</td>
             <td class="text-center"><i class="bi bi-check-circle-fill text-success"></i><br>macOS 13+
-                <sup>1</sup>
+                <sup>2</sup>
             </td>
             <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span class="fs-6 text-muted">Not
                     Supported</span></td>
-            <td class="text-center"><i class="bi bi-calendar-plus" title="Planned" alt="calendar icon"></i><br>Planned
+            <td class="text-center"><i class="bi bi-calendar-plus" title="Planned" alt="calendar icon"></i><br>Planned <sup>1</sup>
             </td>
-        </tr>
-        <tr class="align-middle">
-            <td class="fw-bold"><a href="../docs/reference/terms/#single-device-passkey" target="_blank"><span
-                        class="fst-italic">Single-device</span> passkeys</a>
-            </td>
-            <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span class="fs-6 text-muted">Not
-                    Supported</span></td>
-            <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span class="fs-6 text-muted">Not
-                    Supported</span></td>
-            <td class="text-center"><i class="bi bi-usb-drive fs-4"></i><br>security keys only</td>
-            <td class="text-center"><i class="bi bi-usb-drive fs-4"></i><br>security keys only</td>
-            <td class="text-center"><i class="bi bi-usb-drive fs-4"></i><br>security keys only</td>
-            <td class="text-center"><i class="bi bi-check-circle-fill text-success fs-4"></i></td>
         </tr>
         <tr>
             <td class="fw-bold">Browser Autofill UI</td>
@@ -99,7 +86,7 @@ Passkeys created in **macOS** can be used on:
             <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span class="fs-6 text-muted">Not
                     Supported</span></td>
             <td class="text-center"><i class="bi bi-check-circle-fill text-success"></i><br>Chrome
-                <sup>2</sup><br><br><i
+                <sup>3</sup><br><br><i
                     class="bi bi-calendar-plus" title="Planned" alt="calendar icon"></i><br>Edge<br><br><i class="bi bi-x-circle-fill text-danger"></i><br>Firefox
             </td>
         </tr>
@@ -151,6 +138,19 @@ Passkeys created in **macOS** can be used on:
                         <td class="text-center">Ubuntu</td>
                         <td class="text-center"><a href="/docs/reference/windows/">Windows</a></td>
                     </tr>
+                        <tr class="align-middle">
+                            <td class="fw-bold"><a href="../docs/reference/terms/#device-bound-passkey" target="_blank"><span
+                                        class="fst-italic">Device-bound</span> passkeys</a>
+                            </td>
+                            <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span class="fs-6 text-muted">Not
+                                    Supported</span></td>
+                            <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span class="fs-6 text-muted">Not
+                                    Supported</span></td>
+                            <td class="text-center"><i class="bi bi-usb-drive fs-4"></i><br>on security keys</td>
+                            <td class="text-center"><i class="bi bi-usb-drive fs-4"></i><br>on security keys</td>
+                            <td class="text-center"><i class="bi bi-usb-drive fs-4"></i><br>on security keys</td>
+                            <td class="text-center"><i class="bi bi-check-circle-fill text-success fs-4"></i></td>
+                        </tr>
                     <tr class="align-middle">
                         <td class="fw-bold"><a href="../docs/reference/terms/#device-public-key-dpk" target="_blank">Device
                                 Public
@@ -224,7 +224,8 @@ Passkeys created in **macOS** can be used on:
     </details>
 </div>
 <div class="text-end mb-5 mt-5">
-    <sup>1</sup> See <a href="/docs/reference/macos/#browser-behavior" target="_blank">macOS browser
+    <sup>1</sup> Device-bound passkeys supported
+    <br><sup>2</sup> See <a href="/docs/reference/macos/#browser-behavior" target="_blank">macOS browser
         behavior</a> for caveats
-    <br><sup>2</sup> Chrome M108 and Windows 11 22H2
+    <br><sup>3</sup> Chrome M108 and Windows 11 22H2
 </div>

--- a/content/en/docs/reference/ios.md
+++ b/content/en/docs/reference/ios.md
@@ -37,5 +37,5 @@ To replace a legacy platform credential with a passkey, start a credential regis
 - [Apple landing page for passkeys](https://developer.apple.com/passkeys/)
 - [About the security of passkeys](https://support.apple.com/en-us/HT213305)
 - [Supporting passkeys](https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_passkeys)
-- [Supporting single-device passkeys on security keys](https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_security_key_authentication_using_physical_keys)
+- [Supporting device-bound passkeys on security keys](https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_security_key_authentication_using_physical_keys)
 - [Sample Code](https://developer.apple.com/documentation/authenticationservices/connecting_to_a_service_with_passkeys)

--- a/content/en/docs/reference/macos.md
+++ b/content/en/docs/reference/macos.md
@@ -38,16 +38,16 @@ To replace a legacy platform credential with a passkey, start a credential regis
 
 **Safari**: credentials created in Safari are passkeys, are backed up to iCloud Keychain, and are available in other apps and services.
 
-**Chrome**: credentials created by Chrome are currently [***single-device*** passkeys](/docs/reference/terms/#single-device-passkey), are not backed up to iCloud Keychain, and are ***not available outside of Chrome***.
+**Chrome**: credentials created by Chrome are currently [***device-bound*** passkeys](/docs/reference/terms/#device-bound-passkey), are not backed up to iCloud Keychain, and are ***not available outside of Chrome***.
 
-**Edge**: credentials created by Edge are currently [***single-device*** passkeys](/docs/reference/terms/#single-device-passkey), are not backed up to iCloud Keychain, and are ***not available outside of Edge***.
+**Edge**: credentials created by Edge are currently [***device-bound*** passkeys](/docs/reference/terms/#device-bound-passkey), are not backed up to iCloud Keychain, and are ***not available outside of Edge***.
 
-**Firefox**: passkeys are not currently supported in Firefox on macOS. [***Single-device*** passkeys](/docs/reference/terms/#single-device-passkey) on a FIDO2 security key are supported. [User verification]({{< ref "terms/#user-verification-uv" >}}) is not supported, though, which makes it impossible to implement WebAuthn-based passwordless authentication at this time.
+**Firefox**: passkeys are not currently supported in Firefox on macOS. [***Device-bound*** passkeys](/docs/reference/terms/#device-bound-passkey) on a FIDO2 security key are supported. [User verification]({{< ref "terms/#user-verification-uv" >}}) is not supported, though, which makes it impossible to implement WebAuthn-based passwordless authentication at this time.
 
 ## Resources
 
 - [Apple landing page for passkeys](https://developer.apple.com/passkeys/)
 - [About the security of passkeys](https://support.apple.com/en-us/HT213305)
 - [Supporting passkeys](https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_passkeys)
-- [Supporting single-device passkeys on security keys](https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_security_key_authentication_using_physical_keys)
+- [Supporting device-bound passkeys on security keys](https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_security_key_authentication_using_physical_keys)
 - [Sample Code](https://developer.apple.com/documentation/authenticationservices/connecting_to_a_service_with_passkeys)

--- a/content/en/docs/reference/terms/index.md
+++ b/content/en/docs/reference/terms/index.md
@@ -60,7 +60,7 @@ The _client_ in a cross-device authentication flow is the device where the relyi
 
 ### CDA Authenticator
 
- The _authenticator_ in a cross-device authentication flow is the device generating the FIDO assertion.
+The _authenticator_ in a cross-device authentication flow is the device generating the FIDO assertion.
 
 ## Conditional Mediation
 
@@ -69,6 +69,10 @@ See [_Autofill UI_](#autofill-ui)
 ## Conditional UI
 
 See [_Autofill UI_](#autofill-ui)
+
+## Device-bound passkey
+
+A FIDO2 [Discoverable Credential](#discoverable-credential) that requires [user verification](#user-verification-uv) and is bound to a single authenticator. For example, FIDO2 security keys typically hold device-bound passkeys as the credential cannot leave the device. Device-bound passkeys have been previously referred to as _single-device passkeys_.
 
 ## Device Public Key (DPK)
 
@@ -84,7 +88,7 @@ Just like a passkey, DPKs are unique to each RP.
 
 A Discoverable Credential (previously known as a "resident credential" or "resident key") is a FIDO2/WebAuthn credential that is entirely stored in the authenticator (private key, credential ID, user handle, and other metadata). The [Relying Party (RP)](#relying-party-rp) also stores a copy of the _public_ key and credential ID
 
-[Passkeys](#passkey) (and [single-device passkeys](#single-device-passkey)) are Discoverable Credentials.
+[Passkeys](#passkey) are Discoverable Credentials.
 
 <a href="https://www.w3.org/TR/webauthn-2/#discoverable-credential" target="_blank"><button type="button" class="btn btn-light">Spec Reference <i class="bi bi-box-arrow-up-right ms-2"></i></button></a>
 
@@ -148,7 +152,7 @@ This can refer to either account [bootstrapping](#account-bootstrapping) or [rea
 
 ## Single-device passkey
 
-A FIDO2 [Discoverable Credential](#discoverable-credential) that requires [user verification](#user-verification-uv) and is bound to a single authenticator. For example, FIDO2 security keys hold single-device passkeys as the credential cannot leave the device.
+see [_Device-bound passkey_.](#device-bound-passkey)
 
 ## User Presence (UP)
 

--- a/content/en/docs/reference/windows.md
+++ b/content/en/docs/reference/windows.md
@@ -17,8 +17,8 @@ toc: true
 
 Windows Hello, the local platform authenticator in Windows 10 and 11, has the following capabilities:
 
-- creating and using [***single-device*** passkeys](/docs/reference/terms/#single-device-passkey) that are bound to the local device
-- creating and using [***single-device*** passkeys](/docs/reference/terms/#single-device-passkey) on a FIDO2 security key
+- creating and using [***device-bound*** passkeys](/docs/reference/terms/#device-bound-passkey) on the local device
+- creating and using [***device-bound*** passkeys](/docs/reference/terms/#device-bound-passkey) on a FIDO2 security key
 
 The following is also possible in both Windows 10 and 11:
 


### PR DESCRIPTION
This PR changes "single-device passkey" to "device-bound passkey" site wide and also moves "Device-bound passkeys" from the main device support matrix into Advanced Features (based on developer feedback).