### PR TITLE
Show support status of passkeys in native Apps

### DIFF
--- a/content/en/device-support/_index.md
+++ b/content/en/device-support/_index.md
@@ -218,6 +218,29 @@ Passkeys created in **macOS** can be used on:
                                 alt="calendar icon"></i><br>Planned
                         </td>
                     </tr>
+                    <tr class="align-middle">
+                        <td class="fw-bold">Support in Native Apps</td>
+                        <td class="text-center"><i class="bi bi-wrench-adjustable-circle-fill" title="Beta"
+                                alt="wrench in circle icon"></i><br>Alpha<sup>4</sup>
+                        </td>
+                        <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span
+                                class="fs-6 text-muted">Not
+                                Supported</span></td>
+                        <td class="text-center">
+                          <i class="bi bi-check-circle-fill text-success"></i><br>
+                          <span>iOS 16+<sup>4</sup></span>
+                        </td>
+                        <td class="text-center">
+                          <i class="bi bi-check-circle-fill text-success"></i><br>
+                          <span>macOS 13+<sup>4</sup></span>
+                        </td>
+                        <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span
+                                class="fs-6 text-muted">Not
+                                Supported</span></td>
+                        <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span
+                                class="fs-6 text-muted">Not
+                                Supported</span></td>
+                    </tr>
                 </thead>
             </table>
         </div>
@@ -228,4 +251,5 @@ Passkeys created in **macOS** can be used on:
     <br><sup>2</sup> See <a href="/docs/reference/macos/#browser-behavior" target="_blank">macOS browser
         behavior</a> for caveats
     <br><sup>3</sup> Chrome M108 and Windows 11 22H2
+    <br><sup>4</sup> Android: requires <a href="https://developers.google.com/identity/passkeys/supported-environments#android-passkey-support">Android 9+ and the Credential Manager Alpha</a>; iOS/macOS: see <a href="https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_passkeys">Apple Developer Documentation</a>
 </div>


### PR DESCRIPTION
Yes, it's extending the "Device Matrix" even further, not too happy about it either.

Seamless usage between native apps and the browsers is another interesting use case for many sites, allowing customers to switch seamlessly from a mobile-browser experience to an app-experience, without the user having to need to type in passwords...

Support is still growing and the idea is to reflect and report that in the device support list too.

### Open items

- [ ] Not sure to display either "Not supported" or "Not applicable" for some entries, like e.g. Chrome OS / Ubuntu.
- [ ] What is the status and are the plans on Windows? I haven't found anything at all on this.
- [ ] Where to include: in the device matrix; - or rather the platform pages?

Feedback, opinions if this should be included - or not?