### PR TITLE
Add a passkey example app for Android

### DIFF
--- a/content/en/docs/reference/android.md
+++ b/content/en/docs/reference/android.md
@@ -49,3 +49,4 @@ When an authenticator is not persistently linked, a QR code must be scanned on e
 - [Credential Manager API](https://developer.android.com/training/sign-in/passkeys)
 - [Security of Passkeys in the Google Password Manager](https://security.googleblog.com/2022/10/SecurityofPasskeysintheGooglePasswordManager.html)
 - [Sample app](https://github.com/android/identity-samples/tree/main/Fido2)
+- [Passkey example app](https://github.com/Dashlane/android-passkey-example)

--- a/content/en/docs/reference/android.md
+++ b/content/en/docs/reference/android.md
@@ -44,9 +44,12 @@ When an authenticator is not persistently linked, a QR code must be scanned on e
 
 - The [Device Public Key (DPK)](../terms#device-public-key-dpk) extension is supported in beta, but is currently gated behind a flag in Chrome. Developers can enable `chrome://flags/#enable-experimental-web-platform-features` to experiment with DPK on Android, or on desktop Chrome when using [Cross-Device Authentication](../terms#cross-device-authentication-cda) with an Android device.
 
-## Resources
+## Official Resources
 
 - [Credential Manager API](https://developer.android.com/training/sign-in/passkeys)
 - [Security of Passkeys in the Google Password Manager](https://security.googleblog.com/2022/10/SecurityofPasskeysintheGooglePasswordManager.html)
 - [Sample app](https://github.com/android/identity-samples/tree/main/Fido2)
-- [Passkey example app](https://github.com/Dashlane/android-passkey-example)
+
+## Community Resources
+
+- [Sample native app with passkey support from Dashlane](https://github.com/Dashlane/android-passkey-example)

--- a/content/en/docs/reference/android.md
+++ b/content/en/docs/reference/android.md
@@ -44,12 +44,12 @@ When an authenticator is not persistently linked, a QR code must be scanned on e
 
 - The [Device Public Key (DPK)](../terms#device-public-key-dpk) extension is supported in beta, but is currently gated behind a flag in Chrome. Developers can enable `chrome://flags/#enable-experimental-web-platform-features` to experiment with DPK on Android, or on desktop Chrome when using [Cross-Device Authentication](../terms#cross-device-authentication-cda) with an Android device.
 
-## Official Resources
+## Resources
 
 - [Credential Manager API](https://developer.android.com/training/sign-in/passkeys)
 - [Security of Passkeys in the Google Password Manager](https://security.googleblog.com/2022/10/SecurityofPasskeysintheGooglePasswordManager.html)
 - [Sample app](https://github.com/android/identity-samples/tree/main/Fido2)
 
-## Community Resources
+### Community Resources
 
 - [Sample native app with passkey support from Dashlane](https://github.com/Dashlane/android-passkey-example)


### PR DESCRIPTION
A demo app that allows developers to test passkeys from a native Android app.