### PR TITLE
macOS clarity and term updates

### DIFF
--- a/content/en/device-support/_index.md
+++ b/content/en/device-support/_index.md
@@ -16,8 +16,8 @@ Passkeys created in **iOS or iPadOS** can be used on:
 
 - The same iPhone or iPad
 - iPhones and iPads using the same Apple ID and iCloud Keychain (synced automatically)
-- MacBooks using the same Apple ID and iCloud Keychain (synced automatically)
-- MacBooks using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
+- Macs using the same Apple ID and iCloud Keychain (synced automatically)
+- Macs using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Windows devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Chromebooks and other Chrome OS devices using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Ubuntu devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
@@ -26,7 +26,7 @@ Passkeys created in **Android** can be used on:
 
 - The same Android device
 - Android devices using the same Google account (synced automatically)
-- MacBooks using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
+- Macs using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Windows devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - iPhones and iPads using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Chromebooks and other Chrome OS devices using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
@@ -34,8 +34,14 @@ Passkeys created in **Android** can be used on:
 
 Passkeys created in **macOS** can be used on:
 
-- MacBooks using the same Apple ID and iCloud Keychain (synced automatically)
+- Macs using the same Apple ID and iCloud Keychain (synced automatically)
 - iPhones and iPads using the same Apple ID and iCloud Keychain (synced automatically)
+  - ...which can then be used on:
+    - Windows devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
+    - Chromebooks and other Chrome OS devices using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
+    - Ubuntu devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
+    - Macs signed in with a different Apple ID, using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
+    - iPhones and iPads signed in with a different Apple ID, using [FIDO Cross-Device Authentication](/docs/reference/terms/)
 
 [Device-bound passkeys](/docs/reference/terms/#device-bound-passkey) created in **Windows** can be used on:
 

--- a/content/en/device-support/_index.md
+++ b/content/en/device-support/_index.md
@@ -10,13 +10,13 @@ weight: 100
 
 ## Overview
 
-Support for passkeys is currently rolling out across major operating systems and browsers, and will continue into 2023. This page will be updated as the ecosystem evolves. The [matrix below](#matrix) maps out the various features that support the passkey experience. Additional information about each platform is available in the [Reference section of Docs](/docs/reference/android).
+Support for passkeys is currently rolling out across major operating systems and browsers, and continues throughout 2023. This page will be updated as the ecosystem evolves. The [matrix below](#matrix) maps out the various features that support the passkey experience. Additional information about each platform is available in the [Reference section of Docs](/docs/reference/android).
 
 Passkeys created in **iOS or iPadOS** can be used on:
 
 - The same iPhone or iPad
-- iPhones and iPads using the same Apple ID and iCloud Keychain (synced automatically)
-- Macs using the same Apple ID and iCloud Keychain (synced automatically)
+- iPhones and iPads using the same Apple ID (synced automatically)
+- Macs using the same Apple ID (synced automatically)
 - Macs using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Windows devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Chromebooks and other Chrome OS devices using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
@@ -34,8 +34,8 @@ Passkeys created in **Android** can be used on:
 
 Passkeys created in **macOS** can be used on:
 
-- Macs using the same Apple ID and iCloud Keychain (synced automatically)
-- iPhones and iPads using the same Apple ID and iCloud Keychain (synced automatically)
+- Macs using the same Apple ID (synced automatically)
+- iPhones and iPads using the same Apple ID (synced automatically)
   - ...which can then be used on:
     - Windows devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
     - Chromebooks and other Chrome OS devices using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)

--- a/content/en/device-support/_index.md
+++ b/content/en/device-support/_index.md
@@ -19,7 +19,7 @@ Passkeys created in **iOS or iPadOS** can be used on:
 - MacBooks using the same Apple ID and iCloud Keychain (synced automatically)
 - MacBooks using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Windows devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
-- Chrome OS devices using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
+- Chromebooks and other Chrome OS devices using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Ubuntu devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 
 Passkeys created in **Android** can be used on:
@@ -29,7 +29,7 @@ Passkeys created in **Android** can be used on:
 - MacBooks using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Windows devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - iPhones and iPads using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
-- Chrome OS devices using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
+- Chromebooks and other Chrome OS devices using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 - Ubuntu devices in Edge and Chrome using [FIDO Cross-Device Authentication](/docs/reference/terms/#cross-device-authentication-cda)
 
 Passkeys created in **macOS** can be used on:


### PR DESCRIPTION
- Removes "iCloud Keychain" and just leaves Apple ID (too wordy)
- Replaces "MacBooks" with "Macs" to cover Mac Mini and iMacs
- Adds a fanout under macOS that highlights that passkeys created on a Mac that are synced to an iOS device can then be used on other platforms via CDA
- Updated blurb at top to reference current year