### PR TITLE
add synced passkey to terms

### DIFF
--- a/content/en/docs/reference/terms/index.md
+++ b/content/en/docs/reference/terms/index.md
@@ -152,7 +152,7 @@ see [_Device-bound passkey_.](#device-bound-passkey)
 
 ## Synced passkey
 
-A FIDO2 [Discoverable Credential](#discoverable-credential) that can reliably be used for bootstrap sign-in, without requiring other login challenges such as passwords and OTPs. "Reliable" here means that the passkey should be available to, and usable by, the user whenever they need to sign in. This availability can be achieved through different means: for example, passkey providers could real-time sync passkeys across a user's devices, restore passkeys from a backup whenever a user sets up a new device, offer passkeys across different contexts (a passkey established from an app can be used in the browser when visiting the app’s website), or allow users to [exercise passkeys across devices](#cross-device-authentication-cda) (by, say, using the passkey from a nearby phone when signing in from a laptop).
+A FIDO2 [Discoverable Credential](#discoverable-credential) that can reliably be used for bootstrapping sign-in, without requiring other login challenges such as passwords and OTPs. "Reliable" here means that the passkey should be available to, and usable by, the user whenever they need to sign in. This availability can be achieved through different means: for example, passkey providers could sync passkeys in real-time across a user's devices, restore passkeys from a backup whenever a user sets up a new device, offer passkeys across different contexts (a passkey established from an app can be used in the browser when visiting the app’s website), or allow users to [exercise passkeys across devices](#cross-device-authentication-cda) (by, say, using the passkey from a nearby phone when signing in from a laptop).
 
 ## User Presence (UP)
 

--- a/content/en/docs/reference/terms/index.md
+++ b/content/en/docs/reference/terms/index.md
@@ -116,7 +116,7 @@ The high level, end-user centric term for a FIDO2/WebAuthn [Discoverable Credent
 
 Passkeys are designed to be used without additional login challenges. All passkeys can be used with modern sign in experiences like the [Autofill UI](#autofill-ui) or with a "Sign in with a passkey" button.
 
-From the technical side, there are two flavors of passkeys: [syncable](#syncable-passkey) and [device-bound](#device-bound-passkey).
+From the technical side, there are two flavors of passkeys: [synced](#synced-passkey) and [device-bound](#device-bound-passkey).
 
 ## Platform authenticator
 
@@ -150,7 +150,7 @@ This can refer to either account [bootstrapping](#account-bootstrapping) or [rea
 
 see [_Device-bound passkey_.](#device-bound-passkey)
 
-## Syncable passkey
+## Synced passkey
 
 A FIDO2 [Discoverable Credential](#discoverable-credential) that can reliably be used for bootstrap sign-in, without requiring other login challenges such as passwords and OTPs. "Reliable" here means that the passkey should be available to, and usable by, the user whenever they need to sign in. This availability can be achieved through different means: for example, passkey providers could real-time sync passkeys across a user's devices, restore passkeys from a backup whenever a user sets up a new device, offer passkeys across different contexts (a passkey established from an app can be used in the browser when visiting the app’s website), or allow users to [exercise passkeys across devices](#cross-device-authentication-cda) (by, say, using the passkey from a nearby phone when signing in from a laptop).
 

--- a/content/en/docs/reference/terms/index.md
+++ b/content/en/docs/reference/terms/index.md
@@ -110,17 +110,11 @@ see [_Signing in_.](#signing-in)
 
 ## Passkey
 
-> _sometimes referred to as a multi-device passkey_
+The high level, end-user centric term for a FIDO2/WebAuthn [Discoverable Credential](#discoverable-credential). Like "password", "passkey" is a common noun intended to be used in every day conversation and experiences. Passkeys are designed to be used without additional login challenges.
 
-Short version:
+All passkeys can be used with modern sign in experiences like the [Autofill UI](#autofill-ui) or with a "Sign in with a passkey" button.
 
-A passkey is a FIDO2 [Discoverable Credential](#discoverable-credential) that is protected against device loss.
-
-Longer version:
-
-A FIDO2/WebAuthn credential that can reliably be used for bootstrap sign-in, without requiring other login challenges such as passwords. "Reliable" here means that the passkey should be available to, and usable by, the user whenever they need to sign in. This availability can be achieved through different means: for example, platforms could restore passkeys from a backup whenever a user sets up a new device, offer passkeys across different contexts (a passkey established from an app can be used in the browser when visiting the app’s website), or allow users to [exercise passkeys across devices](#cross-device-authentication-cda) (by, say, using the passkey from a nearby phone when signing in from a laptop).
-
-The important thing is that a passkey is there when the user needs it, and that it can be used without other login challenges. A WebAuthn credential that was created in a private browsing context and disappears when that browsing context is dismissed would not be considered a passkey (since it won’t be there for the user next time they’re trying to sign in). Nor would a U2F credential on a security key (since it requires additional factors for sign-in).
+From the technical side, there are two flavors of passkeys: [syncable](#syncable-passkey) and [device-bound](#device-bound-passkey).
 
 ## Platform authenticator
 
@@ -153,6 +147,10 @@ This can refer to either account [bootstrapping](#account-bootstrapping) or [rea
 ## Single-device passkey
 
 see [_Device-bound passkey_.](#device-bound-passkey)
+
+## Syncable passkey
+
+A FIDO2 [Discoverable Credential](#discoverable-credential) that can reliably be used for bootstrap sign-in, without requiring other login challenges such as passwords and OTPs. "Reliable" here means that the passkey should be available to, and usable by, the user whenever they need to sign in. This availability can be achieved through different means: for example, passkey providers could real-time sync passkeys across a user's devices, restore passkeys from a backup whenever a user sets up a new device, offer passkeys across different contexts (a passkey established from an app can be used in the browser when visiting the app’s website), or allow users to [exercise passkeys across devices](#cross-device-authentication-cda) (by, say, using the passkey from a nearby phone when signing in from a laptop).
 
 ## User Presence (UP)
 

--- a/content/en/docs/reference/terms/index.md
+++ b/content/en/docs/reference/terms/index.md
@@ -110,9 +110,11 @@ see [_Signing in_.](#signing-in)
 
 ## Passkey
 
-The high level, end-user centric term for a FIDO2/WebAuthn [Discoverable Credential](#discoverable-credential). Like "password", "passkey" is a common noun intended to be used in every day conversation and experiences. Passkeys are designed to be used without additional login challenges.
+> Usage: "a passkey" or "passkeys"
 
-All passkeys can be used with modern sign in experiences like the [Autofill UI](#autofill-ui) or with a "Sign in with a passkey" button.
+The high level, end-user centric term for a FIDO2/WebAuthn [Discoverable Credential](#discoverable-credential). Like "password", "passkey" is a common noun intended to be used in every day conversations and experiences.
+
+Passkeys are designed to be used without additional login challenges. All passkeys can be used with modern sign in experiences like the [Autofill UI](#autofill-ui) or with a "Sign in with a passkey" button.
 
 From the technical side, there are two flavors of passkeys: [syncable](#syncable-passkey) and [device-bound](#device-bound-passkey).
 


### PR DESCRIPTION
The terms list did not include "synced passkeys". 

This PR 
- adds "synced passkey"
- moves text from "passkey" to synced passkey"
- changes "passkey" reference to just point to synced and device-bound terms