### PR TITLE
Add link to Mastodon profile

### DIFF
--- a/content/en/about/_index.md
+++ b/content/en/about/_index.md
@@ -45,7 +45,10 @@ Contributing guidance coming soon!
 
 Tim Cappalli | <a href="https://github.com/timcappalli" target="_blank"><i class="bi bi-github color-black"></i></a> <a href="https://twitter.com/timcappalli" target="_blank"><i class="bi bi-twitter-x color-black"></i></a> <a href="https://timcappalli.me/" target="_blank"><i class="bi bi-house-heart color-black"></i></a>
 
-Matthew Miller | <a href="https://github.com/MasterKale" target="_blank"><i class="bi bi-github color-black"></i></a> <a href="https://millerti.me/" target="_blank"><i class="bi bi-house-heart color-black"></i></a>
+Matthew Miller |
+<a href="https://github.com/MasterKale" target="_blank"><i class="bi bi-github color-black"></i></a>
+<a href="https://infosec.exchange/@iamkale" target="_blank"><i class="bi bi-mastodon color-black"></i></a>
+<a href="https://millerti.me/" target="_blank"><i class="bi bi-house-heart color-black"></i></a>
 
 ## Contributors
 


### PR DESCRIPTION
I'm only active on Mastodon these days so I'm updating my social media link accordingly.

![Screenshot 2023-09-26 at 9 09 10 AM](https://github.com/passkeydeveloper/passkeys.dev/assets/5166470/d5ae610b-0db9-43c9-b77f-251ded434dca)
