### PR TITLE
Remove footnote for Chrome on device support page

### DIFF
--- a/content/en/device-support/_index.md
+++ b/content/en/device-support/_index.md
@@ -80,7 +80,7 @@ Passkeys created in **macOS** can be used on:
             <td class="text-center"><i class="bi bi-calendar-plus" title="Planned" alt="calendar icon"></i><br>Planned
             </td>
             <td class="text-center"><i class="bi bi-check-circle-fill text-success"></i><br>Safari<br>Chrome<br>Edge<br>Firefox</td>
-            <td class="text-center"><i class="bi bi-check-circle-fill text-success"></i><br>Safari<br>Chrome <sup>2</sup><br><br><i
+            <td class="text-center"><i class="bi bi-check-circle-fill text-success"></i><br>Safari<br>Chrome<br><i
                     class="bi bi-calendar-plus" title="Planned" alt="calendar icon"></i><br>Edge<br><br><i
                     class="bi bi-x-circle-fill text-danger"></i><br>Firefox</td>
             <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span class="fs-6 text-muted">Not


### PR DESCRIPTION
Follow up from 443ea7715dfed698365c8e8cf11ac1c04a33d69d, and 9bdaa40f0fb86ab9616dc4835aafd3a863cb84eb, merged as #276, this removes the little 2 superscript footnote for Chrome on the browser support page since its caveats were removed.

The actual footnote is still used in other places, but it no longer applies to Chrome as of M118 c: