### PR TITLE
Remove note that Firefox doesn't support UV

### DIFF
--- a/content/en/docs/reference/macos.md
+++ b/content/en/docs/reference/macos.md
@@ -46,7 +46,7 @@ To replace a legacy platform credential with a passkey, start a credential regis
 
 **Edge**: credentials created by Edge are currently [***device-bound*** passkeys](/docs/reference/terms/#device-bound-passkey), are not backed up to iCloud Keychain, and are ***not available outside of Edge***.
 
-**Firefox**: passkeys are not currently supported in Firefox on macOS. [***Device-bound*** passkeys](/docs/reference/terms/#device-bound-passkey) on a FIDO2 security key are supported. [User verification]({{< ref "terms/#user-verification-uv" >}}) is not supported, though, which makes it impossible to implement WebAuthn-based passwordless authentication at this time.
+**Firefox**: passkeys are not currently supported in Firefox on macOS. [***Device-bound*** passkeys](/docs/reference/terms/#device-bound-passkey) on a FIDO2 security key are supported.
 
 ## Resources
 


### PR DESCRIPTION
Firefox supports user verification on FIDO2 security keys as of version 114. https://www.mozilla.org/en-US/firefox/114.0/releasenotes/