### PR TITLE
Add attestation term and links

### DIFF
--- a/content/en/device-support/_index.md
+++ b/content/en/device-support/_index.md
@@ -165,7 +165,7 @@ Passkeys created in **macOS** can be used on:
                         <td class="text-center"><i class="bi bi-check-circle-fill text-success fs-4"></i></td>
                     </tr>
                     <tr class="align-middle">
-                        <td class="fw-bold">Device-bound Passkey Attestation</td>
+                        <td class="fw-bold"><a href="../docs/reference/terms/#attestation" target="_blank">Device-bound Passkey Attestation</a></td>
                         <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
                         <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
                         <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
@@ -174,7 +174,7 @@ Passkeys created in **macOS** can be used on:
                         <td class="text-center"><i class="bi bi-check-circle-fill text-success fs-4"></i></td>
                     </tr>
                     <tr class="align-middle">
-                        <td class="fw-bold">Synced Passkey Attestation</td>
+                        <td class="fw-bold"><a href="../docs/reference/terms/#attestation" target="_blank">Synced Passkey Attestation</a></td>
                         <td class="text-center"><i class="bi bi-x-circle-fill text-danger"></i><br><span
                                 class="fs-6 text-muted">Not
                                 Supported</span></td>

--- a/content/en/docs/reference/terms/index.md
+++ b/content/en/docs/reference/terms/index.md
@@ -28,6 +28,12 @@ A [Relying Party (RP)](#relying-party-rp) authenticates a user without any prior
 
 > Note that this is different from creating an account with a service in the first place.
 
+## Attestation
+
+Attestation is an optional statement provided by an authenticator which can be used by a Relying Party to identify and verify the provenance of the authenticator.
+
+<a href="https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#sctn-attestation" target="_blank"><button type="button" class="btn btn-light">WebAuthn Spec Reference <i class="bi bi-box-arrow-up-right ms-2"></i></button></a>
+
 ## Authentication factor
 
 Information provided by a user (or one of the user’s devices) for purposes of authentication, usually in response to a login challenge. Often categorized into "knowledge factors" (e.g. passwords), "something you have" factors (e.g. another already signed-in device), and "something you are" factors (e.g. biometrics). Note that a single login challenge may collect multiple factors simultaneously.


### PR DESCRIPTION
Changes:
- Adds "Attestation" to terms list
- Add links to Attestation term for "device-bound passkey attestation" and "synced passkey attestation" in Device Support table

Resolves #268 
