### PR TITLE
improve description of discoverable credential

### DIFF
--- a/content/en/docs/reference/terms/index.md
+++ b/content/en/docs/reference/terms/index.md
@@ -82,7 +82,7 @@ A FIDO2 [Discoverable Credential](#discoverable-credential) that is bound to a s
 
 ## Discoverable Credential
 
-A Discoverable Credential (previously known as a "resident credential" or "resident key") is a FIDO2/WebAuthn credential that can be used by a relying party without providing a user ID. As such, all parts of the credential are entirely stored in the authenticator (private key, credential ID, user handle, and other metadata).
+A Discoverable Credential (previously known as a "resident credential" or "resident key") is a FIDO2/WebAuthn credential that can be used by a user to log into a relying party without initially providing a user ID. As such, all parts of the credential are entirely stored in the authenticator (private key, credential ID, user handle, and other metadata).
 
 [Passkeys](#passkey) are Discoverable Credentials.
 

--- a/content/en/docs/reference/terms/index.md
+++ b/content/en/docs/reference/terms/index.md
@@ -82,7 +82,7 @@ A FIDO2 [Discoverable Credential](#discoverable-credential) that is bound to a s
 
 ## Discoverable Credential
 
-A Discoverable Credential (previously known as a "resident credential" or "resident key") is a FIDO2/WebAuthn credential that is entirely stored in the authenticator (private key, credential ID, user handle, and other metadata). The [Relying Party (RP)](#relying-party-rp) also stores a copy of the _public_ key and credential ID
+A Discoverable Credential (previously known as a "resident credential" or "resident key") is a FIDO2/WebAuthn credential that can be used by a relying party without providing a user ID. As such, all parts of the credential are entirely stored in the authenticator (private key, credential ID, user handle, and other metadata).
 
 [Passkeys](#passkey) are Discoverable Credentials.
 


### PR DESCRIPTION
The more relevant distinction to users or developers is whether the RP provides a user ID in the request.