### PR TITLE
Adds Known Issues page

### DIFF
--- a/content/docs/reference/known-issues.md
+++ b/content/docs/reference/known-issues.md
@@ -1,0 +1,29 @@
+---
+title: "Known Issues"
+description: "A list of known issues with passkey implementations"
+date: 2022-09-03T16:09:38.358Z
+draft: false
+images: []
+menu:
+  docs:
+    parent: "reference"
+weight: 1101
+toc: false
+layout: matrix
+---
+
+
+## User Verification
+
+The following list of passkey providers have not implemented [User Verification](../terms#user-verification-uv) in a spec-compliant manner.
+
+| **Provider** | **Architecture** | **UV Required Behavior**      | **UV Flag**              |
+| ------------ | ---------------- | ----------------------------- | ------------------------ |
+| 1Password    | Extension        | ❌ Handles request without UV | ❌ Always replies `True` |
+| 1Password    | Native           | ✅ Performs UV                | ✅ UV flag accurate      |
+| Bitwarden    | Extension        | ❌ Handles request without UV | ❌ Always replies `True` |
+| KeepassXC    | Extension        | ❌ Handles request without UV | ❌ Always replies `True` |
+| ProtonPass   | Extension        | ❌ Handles request without UV | ❌ Always replies `True` |
+| ProtonPass   | Native           | ❌ Handles request without UV | ❌ Always replies `True` |
+
+> **Architecture**: `Extension` = web browser extension, `Native` = OS native app using provider APIs

--- a/content/docs/reference/specs.md
+++ b/content/docs/reference/specs.md
@@ -8,7 +8,7 @@ images: []
 menu:
   docs:
     parent: "reference"
-weight: 1102
+weight: 1111
 toc: true
 ---
 

--- a/content/docs/reference/terms/index.md
+++ b/content/docs/reference/terms/index.md
@@ -8,7 +8,7 @@ images: []
 menu:
   docs:
     parent: "reference"
-weight: 1101
+weight: 1110
 toc: true
 ---
 


### PR DESCRIPTION
This adds a "Known Issues" page under Reference. 

Currently this page lists passkey providers which are not spec-compliant for User Verification: [Preview](https://0f279b6b.passkeys-dev.pages.dev/docs/reference/known-issues/)

Plan to add other things like credProps.