### PR TITLE
Add `passkey-rs` to list of Rust libraries

### DIFF
--- a/content/docs/tools-libraries/libraries.md
+++ b/content/docs/tools-libraries/libraries.md
@@ -17,6 +17,7 @@ toc: true
 ### Rust
 
 - [webauthn_rs: WebAuthn for Rust Server Applications](https://docs.rs/webauthn-rs/latest/webauthn_rs/) (William Brown)
+- [passkey-rs: WebAuthn Authenticators framework that supports passkeys](https://github.com/1Password/passkey-rs) (1Password)
 
 ### TypeScript
 


### PR DESCRIPTION
The [`passkey-rs`](https://github.com/1Password/passkey-rs) library is maintained by @1Password (disclaimer: I work there) and provides both the client & server side authentication logic as well as the transport layer.

Let me know if any other info is needed!