### PR TITLE
Device Support Matrix updates

### DIFF
--- a/content/device-support/_index.md
+++ b/content/device-support/_index.md
@@ -99,9 +99,9 @@ Passkeys created in **macOS** can be used on:
         <span class="fs-6 text-muted"> v13+ <sup><a href="#suptwo">2</a></sup>
       </td>
       <td class="text-center">
-        {{< icon-circle-x-filled fill="red" size=30 >}}
+        {{< icon-circle-check stroke="grey" size=30 >}}
         <br />
-        <span class="fs-6 text-muted"> Not Supported </span>
+        <span class="fs-6 text-muted">Browser<br>Extensions</span>
       </td>
       <td class="text-center">
         {{< icon-calendar-clock size="30" >}}

--- a/content/device-support/_index.md
+++ b/content/device-support/_index.md
@@ -393,18 +393,18 @@ Passkeys created in **macOS** can be used on:
         <td class="text-center">
           {{< icon-circle-check stroke="green" size=30 >}}
           <br />
-          <span class="fs-6 text-muted">Supported </span><sup><a href="#supsix">6</a></sup>
+          <span class="fs-6 text-muted">WebView </span><sup><a href="#supsix">6</a></sup>
         </td>
         <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
         <td class="text-center">
           {{< icon-circle-check stroke="green" size=30 >}}
           <br />
-          <span class="fs-6 text-muted">Supported </span><sup><a href="#supseven">7</a></sup>
+          <span class="fs-6 text-muted">WKWebView </span><sup><a href="#supseven">7</a></sup>
         </td>
         <td class="text-center">
           {{< icon-circle-check stroke="green" size=30 >}}
           <br />
-          <span class="fs-6 text-muted">Partially<br>Supported </span><sup><a href="#supeight">8</a></sup>
+          <span class="fs-6 text-muted">WKWebView </span><sup><a href="#supeight">8</a></sup>
         </td>
         <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
         <td class="text-center">
@@ -604,11 +604,11 @@ Passkeys created in **macOS** can be used on:
   Partial support (requires Windows changes)
   <br />
   <sup id="supsix">6</sup>
-  See caveats on Android reference page
+  See details on the <a href="/docs/reference/android/#webviews" target="_blank">Android reference page</a>
   <br />
   <sup id="supseven">7</sup>
-  See caveats on iOS reference page
+  See details on <a href="/docs/reference/ios/#webviews" target="_blank">iOS reference page</a>
   <br />
   <sup id="supeight">8</sup>
-  See caveats on macOS reference page
+  See details on <a href="/docs/reference/macos/#webviews" target="_blank">macOS reference page</a>
 </div>

--- a/content/device-support/_index.md
+++ b/content/device-support/_index.md
@@ -53,7 +53,7 @@ Passkeys created in **macOS** can be used on:
   <table class="table table-striped mt-0">
     <thead>
       <tr class="fw-bold">
-        <td>Capability</td>
+        <td class="fst-italic">Capability</td>
         <td class="text-center">
           <a href="/docs/reference/android/">Android</a>
         </td>
@@ -70,7 +70,7 @@ Passkeys created in **macOS** can be used on:
     </thead>
     <tr>
       <td>
-        <span class="fw-bold">
+        <span>
           <a href="../docs/reference/terms/#synced-passkey" target="_blank">
             Synced Passkeys
           </a>
@@ -112,7 +112,7 @@ Passkeys created in **macOS** can be used on:
       </td>
     </tr>
     <tr>
-      <td class="fw-bold">
+      <td>
         <a href="../docs/reference/terms/#autofill-ui" target="_blank">
           Browser Autofill UI
         </a>
@@ -192,7 +192,7 @@ Passkeys created in **macOS** can be used on:
         </a>
         <br />
         <a href="../docs/reference/terms/#cda-authenticator" target="_blank">
-          <span class="fst-italic fw-bold">Authenticator</span>
+          <span class="fst-italic">Authenticator</span>
         </a>
       </td>
       <td class="text-center">
@@ -219,7 +219,7 @@ Passkeys created in **macOS** can be used on:
         </a>
         <br />
         <a href="../docs/reference/terms/#cda-client" target="_blank">
-          <span class="fst-italic fw-bold">Client</span>
+          <span class="fst-italic">Client</span>
         </a>
       </td>
       <td class="text-center">
@@ -295,107 +295,124 @@ Passkeys created in **macOS** can be used on:
       </td>
     </tr>
   </table>
-  <details>
-    <summary><strong>Native Apps</strong></summary>
-    <div id="device-support-table" class="table-responsive">
-      <table class="table table-striped mt-0">
-        <thead>
-          <tr>
-            <td>Invocation Method</td>
-            <td class="text-center fw-bold">
-              <a href="/docs/reference/android/">Android</a>
-            </td>
-            <td class="text-center fw-bold">Chrome OS</td>
-            <td class="text-center fw-bold">
-              <a href="/docs/reference/ios/">iOS/iPad OS</a>
-            </td>
-            <td class="text-center fw-bold">
-              <a href="/docs/reference/macos/">macOS</a>
-            </td>
-            <td class="text-center fw-bold">Ubuntu</td>
-            <td class="text-center fw-bold">
-              <a href="/docs/reference/windows/">Windows</a>
-            </td>
-          </tr>
-          <tr class="align-middle">
-            <td class="fw-bold">
-                Native Platform APIs
-            </td>
-            <td class="text-center">
-              {{< icon-circle-check-filled fill="green" size=30 >}}
-            </td>
-            <td class="text-center">
-              <span class="fs-6 text-muted">n/a</span>
-            </td>
-            <td class="text-center">
-              {{< icon-circle-check-filled fill="green" size=30 >}}
-            </td>
-            <td class="text-center">
-              {{< icon-circle-check-filled fill="green" size=30 >}}
-            </td>
-            <td class="text-center">
-              {{< icon-circle-x-filled fill="red" size=30 >}}
-              <br />
-              <span class="fs-6 text-muted">Not Supported</span>
-            </td>
-            <td class="text-center">
-              {{< icon-circle-check-filled fill="green" size=30 >}}
-            </td>
-          </tr>
-          <tr class="align-middle">
-            <td class="fw-bold">
-              System WebView
-            </td>
-            <td class="text-center">
-              {{< icon-circle-check-filled fill="green" size=30 >}}
-              <br />
-              <span class="fs-6 text-muted">Chrome<br>Custom Tabs</span>
-            </td>
-            <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
-            <td class="text-center">
-              {{< icon-circle-check-filled fill="green" size=30 >}}
-              <br />
-              <span class="fs-6 text-muted">ASWebAuthentication<wbr>Session</span>
-            </td>
-            <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
-            <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
-            <td class="text-center">
-              {{< icon-circle-check-filled fill="green" size=30 >}}
-              <br />
-              <span class="fs-6 text-muted">Edge WebView2</span>
-            </td>
-          </tr>
-          <tr class="align-middle">
-            <td class="fw-bold">
-              Embedded WebView
-            </td>
-            <td class="text-center">
-              {{< icon-circle-x-filled fill="red" size=30 >}}
-              <br />
-              <span class="fs-6 text-muted">Not Supported</span>
-            </td>
-            <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
-            <td class="text-center">
-              {{< icon-circle-x-filled fill="red" size=30 >}}
-              <br />
-              <span class="fs-6 text-muted">Not Supported</span>
-            </td>
-            <td class="text-center">
-              {{< icon-circle-x-filled fill="red" size=30 >}}
-              <br />
-              <span class="fs-6 text-muted">Not Supported</span>
-            </td>
-            <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
-            <td class="text-center">
-              {{< icon-circle-x-filled fill="red" size=30 >}}
-              <br />
-              <span class="fs-6 text-muted">Not Supported</span>
-            </td>
-          </tr>
-        </thead>
-      </table>
-    </div>
-  </details>
+
+## Native Apps
+
+  <table class="table table-striped mt-0">
+    <thead>
+      <tr>
+        <td class="fw-bold fst-italic">Invocation Method</td>
+        <td class="text-center fw-bold">
+          <a href="/docs/reference/android/">Android</a>
+        </td>
+        <td class="text-center fw-bold">Chrome OS</td>
+        <td class="text-center fw-bold">
+          <a href="/docs/reference/ios/">iOS/iPad OS</a>
+        </td>
+        <td class="text-center fw-bold">
+          <a href="/docs/reference/macos/">macOS</a>
+        </td>
+        <td class="text-center fw-bold">Ubuntu</td>
+        <td class="text-center fw-bold">
+          <a href="/docs/reference/windows/">Windows</a>
+        </td>
+      </tr>
+      <tr class="align-middle">
+        <td>
+            Native Platform APIs
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+        <td class="text-center">
+          <span class="fs-6 text-muted">n/a</span>
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+        <td class="text-center">
+          {{< icon-circle-x-filled fill="red" size=30 >}}
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+      </tr>
+      <tr class="align-middle">
+        <td>
+            Default Browser
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+        </td>
+      </tr>
+      <tr class="align-middle">
+        <td>
+          System WebView
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+          <br />
+          <span class="fs-6 text-muted"><a href="https://developer.chrome.com/docs/android/custom-tabs/guide-get-started" target="_blank">Custom Tabs</a></span>
+        </td>
+        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+          <br />
+          <span class="fs-6 text-muted"><a href="https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession" target="_blank">ASWebAuthentication<wbr>Session</a></span>
+        </td>
+        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+          <br />
+          <span class="fs-6 text-muted"><a href="https://developer.microsoft.com/en-us/microsoft-edge/webview2/" target="_blank">Edge WebView2</a></span>
+        </td>
+      </tr>
+      <tr class="align-middle">
+        <td>
+          Embedded WebView
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check stroke="green" size=30 >}}
+          <br />
+          <span class="fs-6 text-muted">Supported </span><sup><a href="#supsix">6</a></sup>
+        </td>
+        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center">
+          {{< icon-circle-check stroke="green" size=30 >}}
+          <br />
+          <span class="fs-6 text-muted">Supported </span><sup><a href="#supseven">7</a></sup>
+        </td>
+        <td class="text-center">
+          {{< icon-circle-check stroke="green" size=30 >}}
+          <br />
+          <span class="fs-6 text-muted">Partially<br>Supported </span><sup><a href="#supeight">8</a></sup>
+        </td>
+        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center">
+          {{< icon-circle-x-filled fill="red" size=30 >}}
+        </td>
+      </tr>
+    </thead>
+  </table>
   <details>
     <summary><strong>Advanced Capabilities</strong></summary>
     <div id="device-support-table" class="table-responsive">
@@ -585,4 +602,13 @@ Passkeys created in **macOS** can be used on:
   <br />
   <sup id="supfive">5</sup>
   Partial support (requires Windows changes)
+  <br />
+  <sup id="supsix">6</sup>
+  See caveats on Android reference page
+  <br />
+  <sup id="supseven">7</sup>
+  See caveats on iOS reference page
+  <br />
+  <sup id="supeight">8</sup>
+  See caveats on macOS reference page
 </div>

--- a/content/device-support/_index.md
+++ b/content/device-support/_index.md
@@ -413,8 +413,11 @@ Passkeys created in **macOS** can be used on:
       </tr>
     </thead>
   </table>
+
+## Advanced Capabilities
+
   <details>
-    <summary><strong>Advanced Capabilities</strong></summary>
+    <summary><strong>Details</strong></summary>
     <div id="device-support-table" class="table-responsive">
       <table class="table table-striped mt-0">
         <thead>

--- a/content/device-support/_index.md
+++ b/content/device-support/_index.md
@@ -168,9 +168,9 @@ Passkeys created in **macOS** can be used on:
         </span>
       </td>
       <td class="text-center">
-        {{< icon-circle-x-filled fill="red" size=30 >}}
+        {{< icon-circle-check stroke="grey" size=30 >}}
         <br />
-        <span class="fs-6 text-muted">Not Supported</span>
+        <span class="fs-6 text-muted">Browser<br>Extensions</span>
       </td>
       <td class="text-center">
         {{< icon-circle-check-filled fill="green" size=30 >}}

--- a/content/device-support/_index.md
+++ b/content/device-support/_index.md
@@ -185,7 +185,7 @@ Passkeys created in **macOS** can be used on:
         <br />
       </td>
     </tr>
-    <tr class="align-middle">
+    <tr class="align-top">
       <td>
         <a href="../docs/reference/terms/#cross-device-authentication-cda" target="_blank">
           Cross-Device Authentication
@@ -201,16 +201,16 @@ Passkeys created in **macOS** can be used on:
         <span class="fs-6 text-muted">v9+</span>
       </td>
       <td class="text-center">
-        <span class="fs-6 text-muted">n/a</span>
+        <span class="fs-6 text-muted">-<br>n/a</span>
       </td>
       <td class="text-center">
         {{< icon-circle-check-filled fill="green" size=30 >}}
         <br />
         <span class="fs-6 text-muted">v16+</span>
       </td>
-      <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
-      <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
-      <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+      <td class="text-center"><span class="fs-6 text-muted">-<br>n/a</span></td>
+      <td class="text-center"><span class="fs-6 text-muted">-<br>n/a</span></td>
+      <td class="text-center"><span class="fs-6 text-muted">-<br>n/a</span></td>
     </tr>
     <tr>
       <td>
@@ -363,7 +363,7 @@ Passkeys created in **macOS** can be used on:
           {{< icon-circle-check-filled fill="green" size=30 >}}
         </td>
       </tr>
-      <tr class="align-middle">
+      <tr class="align-top">
         <td>
           System WebView
         </td>
@@ -372,7 +372,7 @@ Passkeys created in **macOS** can be used on:
           <br />
           <span class="fs-6 text-muted"><a href="https://developer.chrome.com/docs/android/custom-tabs/guide-get-started" target="_blank">Custom Tabs</a></span>
         </td>
-        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center"><span class="fs-6 text-muted">-<br>n/a</span></td>
         <td class="text-center">
           {{< icon-circle-check-filled fill="green" size=30 >}}
           <br />
@@ -383,14 +383,14 @@ Passkeys created in **macOS** can be used on:
           <br />
           <span class="fs-6 text-muted lh-1"><a href="https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession" target="_blank">ASWeb<br>Authentication<br>Session</a></span>
         </td>
-        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center"><span class="fs-6 text-muted">-<br>n/a</span></td>
         <td class="text-center">
           {{< icon-circle-check-filled fill="green" size=30 >}}
           <br />
           <span class="fs-6 text-muted"><a href="https://developer.microsoft.com/en-us/microsoft-edge/webview2/" target="_blank">Edge<br>WebView2</a></span>
         </td>
       </tr>
-      <tr class="align-middle">
+      <tr class="align-top">
         <td>
           Embedded WebView
         </td>
@@ -399,7 +399,7 @@ Passkeys created in **macOS** can be used on:
           <br />
           <span class="fs-6 text-muted">WebView </span><sup><a href="#fn6">6</a></sup>
         </td>
-        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center"><span class="fs-6 text-muted">-<br>n/a</span></td>
         <td class="text-center">
           {{< icon-circle-check stroke="green" size=30 >}}
           <br />
@@ -410,7 +410,7 @@ Passkeys created in **macOS** can be used on:
           <br />
           <span class="fs-6 text-muted">WKWebView </span><sup><a href="#sup8">8</a></sup>
         </td>
-        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center"><span class="fs-6 text-muted">-<br>n/a</span></td>
         <td class="text-center">
           {{< icon-circle-x-filled fill="red" size=30 >}}
         </td>

--- a/content/device-support/_index.md
+++ b/content/device-support/_index.md
@@ -85,7 +85,7 @@ Passkeys created in **macOS** can be used on:
         {{< icon-calendar-clock size="30" >}}
         <br />
         <span class="fs-6">
-        Planned <sup><a href="#supone">1</a></sup>
+        Planned <sup><a href="#fn1">1</a></sup>
         </span>
       </td>
       <td class="text-center">
@@ -96,7 +96,7 @@ Passkeys created in **macOS** can be used on:
       <td class="text-center">
         {{< icon-circle-check-filled fill="green" size=30 >}}
         <br />
-        <span class="fs-6 text-muted"> v13+ <sup><a href="#suptwo">2</a></sup>
+        <span class="fs-6 text-muted"> v13+ <sup><a href="#fn2">2</a></sup>
       </td>
       <td class="text-center">
         {{< icon-circle-check stroke="grey" size=30 >}}
@@ -107,7 +107,7 @@ Passkeys created in **macOS** can be used on:
         {{< icon-calendar-clock size="30" >}}
         <br />
         <span class="fs-6">
-        Planned <sup><a href="#supone">1</a></sup>
+        Planned <sup><a href="#fn1">1</a></sup>
         </span>
       </td>
     </tr>
@@ -176,11 +176,11 @@ Passkeys created in **macOS** can be used on:
         {{< icon-circle-check-filled fill="green" size=30 >}}
         <span class="fs-6">
         <br />
-        Chrome 108+ <sup><a href="#supthree">3</a></sup>
+        Chrome 108+ <sup><a href="#fn3">3</a></sup>
         <br />
-        Firefox 122+ <sup><a href="#supthree">3</a></sup>
+        Firefox 122+ <sup><a href="#fn3">3</a></sup>
         <br />
-        Edge 122+ <sup><a href="#supthree">3</a></sup>
+        Edge 122+ <sup><a href="#fn3">3</a></sup>
         </span>
         <br />
       </td>
@@ -393,18 +393,18 @@ Passkeys created in **macOS** can be used on:
         <td class="text-center">
           {{< icon-circle-check stroke="green" size=30 >}}
           <br />
-          <span class="fs-6 text-muted">WebView </span><sup><a href="#supsix">6</a></sup>
+          <span class="fs-6 text-muted">WebView </span><sup><a href="#fn6">6</a></sup>
         </td>
         <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
         <td class="text-center">
           {{< icon-circle-check stroke="green" size=30 >}}
           <br />
-          <span class="fs-6 text-muted">WKWebView </span><sup><a href="#supseven">7</a></sup>
+          <span class="fs-6 text-muted">WKWebView </span><sup><a href="#fn7">7</a></sup>
         </td>
         <td class="text-center">
           {{< icon-circle-check stroke="green" size=30 >}}
           <br />
-          <span class="fs-6 text-muted">WKWebView </span><sup><a href="#supeight">8</a></sup>
+          <span class="fs-6 text-muted">WKWebView </span><sup><a href="#sup8">8</a></sup>
         </td>
         <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
         <td class="text-center">
@@ -485,7 +485,7 @@ Passkeys created in **macOS** can be used on:
             <td class="text-center">
               {{< icon-settings-code size=30 >}}
               <br />
-              <span class="fs-6">Chrome</span> <sup><a href="#supfour">4</a></sup>
+              <span class="fs-6">Chrome</span> <sup><a href="#fn4">4</a></sup>
             </td>
             <td class="text-center">
               {{< icon-circle-x-filled fill="red" size=30 >}}
@@ -496,9 +496,9 @@ Passkeys created in **macOS** can be used on:
               {{< icon-settings-code size=30 >}}
               <span class="fs-6">
               <br />
-              Chrome <sup><a href="#supfour">4</a></sup>
+              Chrome <sup><a href="#fn4">4</a></sup>
               <br />
-              Edge <sup><a href="#supfour">4</a></sup>
+              Edge <sup><a href="#fn4">4</a></sup>
               <br />
               <br />
               {{< icon-circle-x-filled fill="red" size=30 >}}
@@ -512,9 +512,9 @@ Passkeys created in **macOS** can be used on:
               {{< icon-settings-code size=30 >}}
               <span class="fs-6">
               <br />
-              Chrome <sup><a href="#supfour">4</a></sup>
+              Chrome <sup><a href="#fn4">4</a></sup>
               <br />
-              Edge <sup><a href="#supfour">4</a></sup>
+              Edge <sup><a href="#fn4">4</a></sup>
               <br />
               <br />
               {{< icon-circle-x-filled fill="red" size=30 >}}
@@ -528,9 +528,9 @@ Passkeys created in **macOS** can be used on:
               {{< icon-settings-code size=30 >}}
               <span class="fs-6">
               <br />
-              Chrome <sup><a href="#supfive">4</a> <a href="#supfive">5</a></sup>
+              Chrome <sup><a href="#fn5">4</a> <a href="#fn5">5</a></sup>
               <br />
-              Edge <sup><a href="#supfour">4</a> <a href="#supfive">5</a></sup>
+              Edge <sup><a href="#fn4">4</a> <a href="#fn5">5</a></sup>
               <br />
               <br />
               {{< icon-circle-x-filled fill="red" size=30 >}}
@@ -587,31 +587,31 @@ Passkeys created in **macOS** can be used on:
   </details>
 </div>
 <div class="text-end mb-5 mt-5">
-  <sup id="supone">1</sup>
+  <sup id="fn1">1</sup>
   Device-bound passkeys supported
   <br />
-  <sup id="suptwo">2</sup>
+  <sup id="fn2">2</sup>
   See
   <a href="/docs/reference/macos/#browser-behavior" target="_blank">
     macOS browser behavior
   </a>
   for caveats
   <br />
-  <sup id="supthree">3</sup>
+  <sup id="fn3">3</sup>
   Windows 11 22H2+
   <br />
-  <sup id="supfour">4</sup>
+  <sup id="fn4">4</sup>
   Experimental (behind flag)
   <br />
-  <sup id="supfive">5</sup>
+  <sup id="fn5">5</sup>
   Partial support (requires Windows changes)
   <br />
-  <sup id="supsix">6</sup>
+  <sup id="fn6">6</sup>
   See details on the <a href="/docs/reference/android/#webviews" target="_blank">Android reference page</a>
   <br />
-  <sup id="supseven">7</sup>
+  <sup id="fn7">7</sup>
   See details on <a href="/docs/reference/ios/#webviews" target="_blank">iOS reference page</a>
   <br />
-  <sup id="supeight">8</sup>
+  <sup id="fn8">8</sup>
   See details on <a href="/docs/reference/macos/#webviews" target="_blank">macOS reference page</a>
 </div>

--- a/content/device-support/_index.md
+++ b/content/device-support/_index.md
@@ -376,14 +376,18 @@ Passkeys created in **macOS** can be used on:
         <td class="text-center">
           {{< icon-circle-check-filled fill="green" size=30 >}}
           <br />
-          <span class="fs-6 text-muted"><a href="https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession" target="_blank">ASWebAuthentication<wbr>Session</a></span>
+          <span class="fs-6 text-muted lh-1"><a href="https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession" target="_blank">ASWeb<br>Authentication<br>Session</a></span>
         </td>
-        <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
+        <td class="text-center">
+          {{< icon-circle-check-filled fill="green" size=30 >}}
+          <br />
+          <span class="fs-6 text-muted lh-1"><a href="https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession" target="_blank">ASWeb<br>Authentication<br>Session</a></span>
+        </td>
         <td class="text-center"><span class="fs-6 text-muted">n/a</span></td>
         <td class="text-center">
           {{< icon-circle-check-filled fill="green" size=30 >}}
           <br />
-          <span class="fs-6 text-muted"><a href="https://developer.microsoft.com/en-us/microsoft-edge/webview2/" target="_blank">Edge WebView2</a></span>
+          <span class="fs-6 text-muted"><a href="https://developer.microsoft.com/en-us/microsoft-edge/webview2/" target="_blank">Edge<br>WebView2</a></span>
         </td>
       </tr>
       <tr class="align-middle">

--- a/content/docs/reference/android.md
+++ b/content/docs/reference/android.md
@@ -45,7 +45,36 @@ When an authenticator is not persistently linked, a QR code must be scanned on e
 
 ## Platform Notes
 
-- **Credential Manager** is a new Android Jetpack API that supports multiple sign-in methods, including passkeys, in a single API, thus simplifying the integration for developers.<br><br><a href="https://developer.android.com/training/sign-in/passkeys" target="_blank"><button type="button" class="btn btn-light">Credential Manager API <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-external-link" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6" /><path d="M11 13l9 -9" /><path d="M15 4h5v5" /></svg></button></a><br><br><a href="https://developer.android.com/training/sign-in/fido2-migration" target="_blank"><button type="button" class="btn btn-light">FIDO2 API to Credential Manager Migration <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-external-link" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 6h-6a2 2 0 0 0 -2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-6" /><path d="M11 13l9 -9" /><path d="M15 4h5v5" /></svg></button></a>
+- **Credential Manager** is a new Android Jetpack API that supports multiple sign-in methods, including passkeys, in a single API, thus simplifying the integration for developers.<br><br><a href="https://developer.android.com/training/sign-in/passkeys" target="_blank"><button type="button" class="btn btn-light">Credential Manager API {{< icon-external-link size=24 >}}</button></a>
+
+### WebViews
+
+#### Embedded WebViews (EWV)
+
+`WebView` is the embedded WebView (EWV) on Android. Embedded WebViews allow the calling app full control over the embedded web session, including modifying and intercepting requests, so many web platform features are limited in these contexts.
+
+WebAuthn is currently not directly supported in embedded WebViews on Android, but adding additional code can allow you to break out of the EWV to call the platform's Credential Manager APIs.
+
+This is documented at [Android Developer: "Integrate Credential Manager with WebView {{< icon-external-link size=20 >}}](https://developer.android.com/training/sign-in/credential-manager-webview).
+
+> **NOTE:**<br>
+> Embedded WebViews run in the context of the calling app, meaning only passkeys for the linked web domain (RP ID) can be created or used for sign in.
+>
+> Said differently, only use EWV when sign in is handled by your own service (non-federated). When supporting multiple identity providers, System WebView should be used (see below).
+
+<a href="https://developer.android.com/develop/ui/views/layout/webapps/webview" target="_blank"><button type="button" class="btn btn-light">WebView docs @ Android Developer {{< icon-external-link size=24 >}}</button></a>
+
+<!-- TODO: add screenshot example -->
+
+#### System WebViews (SWV)
+
+`Custom Tabs` is the System WebView (SWV) on Android. All web platform features that are available in the user's default browser, including WebAuthn, are available in a custom tab.
+
+Sites loaded in `Custom Tabs` are isolated from the calling app and run in the context of the top level site, just like in a full browser. This means that sign in flows on third party domains, such as a federated identity provider, can use passkeys for signing in.
+
+<a href="https://developer.chrome.com/docs/android/custom-tabs/guide-get-started" target="_blank"><button type="button" class="btn btn-light">Custom Tabs docs @ Android Developer {{< icon-external-link size=24 >}}</button></a>
+
+<!-- TODO: add screenshot example -->
 
 ### User Verification Behavior
 

--- a/content/docs/reference/android.md
+++ b/content/docs/reference/android.md
@@ -24,6 +24,8 @@ Android 14 adds the following capabilities:
 
 - creating and using passkeys in a [third-party passkey provider](../terms/#third-party-passkey-provider)
 
+## Platform Notes
+
 ### Cross-Device Authentication
 
 Android devices can be an [authenticator](../terms/#cda-authenticator) for [FIDO Cross-Device Authentication (CDA)](../terms#cross-device-authentication-cda).
@@ -43,7 +45,7 @@ macOS (Safari and native apps), iOS (global), and iPadOS (global) do not support
 
 When an authenticator is not persistently linked, a QR code must be scanned on every use.
 
-## Platform Notes
+### Native APIs
 
 - **Credential Manager** is a new Android Jetpack API that supports multiple sign-in methods, including passkeys, in a single API, thus simplifying the integration for developers.<br><br><a href="https://developer.android.com/training/sign-in/passkeys" target="_blank"><button type="button" class="btn btn-light">Credential Manager API {{< icon-external-link size=24 >}}</button></a>
 

--- a/content/docs/reference/android.md
+++ b/content/docs/reference/android.md
@@ -70,7 +70,7 @@ This is documented at [Android Developer: "Integrate Credential Manager with Web
 
 #### System WebViews (SWV)
 
-`Custom Tabs` is the System WebView (SWV) on Android. All web platform features that are available in the user's default browser, including WebAuthn, are available in a custom tab.
+`Custom Tabs` is the System WebView (SWV) on Android. All Web Platform features that are available in the user's default browser, including WebAuthn, are available in a custom tab.
 
 Sites loaded in `Custom Tabs` are isolated from the calling app and run in the context of the top level site, just like in a full browser. This means that sign in flows on third party domains, such as a federated identity provider, can use passkeys for signing in.
 

--- a/content/docs/reference/ios.md
+++ b/content/docs/reference/ios.md
@@ -58,7 +58,7 @@ To replace a legacy platform credential with a passkey, start a credential regis
 
 #### System WebViews
 
-`ASWebAuthenticationSession` is the System WebView (SWV) on iOS and iPadOS for authentication flows. All web platform features that are available in Safari, including WebAuthn, are available in a `ASWebAuthenticationSession` instance.
+`ASWebAuthenticationSession` is the System WebView (SWV) on iOS and iPadOS for authentication flows. All Web Platform features that are available in Safari, including WebAuthn, are available in a `ASWebAuthenticationSession` instance.
 
 Sites loaded in `ASWebAuthenticationSession` are isolated from the calling app and run in the context of the top level site, just like in a full browser. This means that sign in flows on third party domains, such as a federated identity provider, can use passkeys for signing in.
 

--- a/content/docs/reference/ios.md
+++ b/content/docs/reference/ios.md
@@ -41,6 +41,31 @@ WebAuthn credentials created using the platform authenticator in iOS/iPadOS 15 a
 <!-- TODO: cross link to generic content about "upgrading to a passkey" -->
 To replace a legacy platform credential with a passkey, start a credential registration ceremony and pass **the same user handle** (user.id) in the request. iOS/iPadOS will overwrite the legacy credential with a new passkey that will be backed up to iCloud Keychain.
 
+### WebViews
+
+#### Embedded WebViews
+
+`WKWebView` is the embedded WebView (EWV) on iOS and iPadOS. Embedded WebViews allow the calling app full control over the embedded web session, including modifying and intercepting requests, so many web platform features are limited in these contexts.
+
+> **NOTE:**<br>
+> Embedded WebViews run in the context of the calling app, meaning only passkeys for the linked web domain (RP ID) can be created or used for sign in.
+>
+> Said differently, only use EWV when sign in is handled by your own service (non-federated). When supporting multiple identity providers, System WebView should be used (see below).
+
+<a href="https://developer.apple.com/documentation/webkit/wkwebview" target="_blank"><button type="button" class="btn btn-light">WKWebView docs @ Apple Developer {{< icon-external-link size=24 >}}</button></a>
+
+<!-- TODO: add screenshot example -->
+
+#### System WebViews
+
+`ASWebAuthenticationSession` is the System WebView (SWV) on iOS and iPadOS for authentication flows. All web platform features that are available in Safari, including WebAuthn, are available in a `ASWebAuthenticationSession` instance.
+
+Sites loaded in `ASWebAuthenticationSession` are isolated from the calling app and run in the context of the top level site, just like in a full browser. This means that sign in flows on third party domains, such as a federated identity provider, can use passkeys for signing in.
+
+<a href="https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession" target="_blank"><button type="button" class="btn btn-light">ASWebAuthenticationSession docs @ Apple Developer {{< icon-external-link size=24 >}}</button></a>
+
+<!-- TODO: add screenshot example -->
+
 ### User Verification Behavior
 
 When a user tries to interact with a passkey on iOS or iPadOS, an available screen unlock method is used for user verification. Users can configure a passcode and Touch ID or Face ID as their screen unlock.

--- a/content/docs/reference/macos.md
+++ b/content/docs/reference/macos.md
@@ -63,9 +63,9 @@ To replace a legacy platform credential with a passkey, start a credential regis
 
 #### System WebViews
 
-`ASWebAuthenticationSession` is the System WebView (SWV) on macOS for authentication flows. All web platform features that are available in Safari, including WebAuthn, are available in a `ASWebAuthenticationSession` instance.
+`ASWebAuthenticationSession` is the System WebView (SWV) on macOS for authentication flows. The user's default web browser will be invoked, allowing any supported Web Platform features, including WebAuthn, for the `ASWebAuthenticationSession` instance.
 
-Sites loaded in `ASWebAuthenticationSession` are isolated from the calling app and run in the context of the top level site, just like in a full browser. This means that sign in flows on third party domains, such as a federated identity provider, can use passkeys for signing in.
+Sites loaded in `ASWebAuthenticationSession` are isolated from the calling app and run in the context of the top level site, just like in a full browser instance. This means that sign in flows on third party domains, such as a federated identity provider, can use passkeys for signing in.
 
 <a href="https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession" target="_blank"><button type="button" class="btn btn-light">ASWebAuthenticationSession docs @ Apple Developer {{< icon-external-link size=24 >}}</button></a>
 

--- a/content/docs/reference/macos.md
+++ b/content/docs/reference/macos.md
@@ -46,6 +46,31 @@ To replace a legacy platform credential with a passkey, start a credential regis
 
 **Edge**: credentials created by Edge are currently [***device-bound*** passkeys](/docs/reference/terms/#device-bound-passkey), are not backed up to iCloud Keychain, and are ***not available outside of Edge***.
 
+### WebViews
+
+#### Embedded WebViews
+
+`WKWebView` is the embedded WebView (EWV) on macOS. Embedded WebViews allow the calling app full control over the embedded web session, including modifying and intercepting requests, so many web platform features are limited in these contexts.
+
+> **NOTE:**<br>
+> Embedded WebViews run in the context of the calling app, meaning only passkeys for the linked web domain (RP ID) can be created or used for sign in.
+>
+> Said differently, only use EWV when sign in is handled by your own service (non-federated). When supporting multiple identity providers, System WebView should be used (see below).
+
+<a href="https://developer.apple.com/documentation/webkit/wkwebview" target="_blank"><button type="button" class="btn btn-light">WKWebView docs @ Apple Developer {{< icon-external-link size=24 >}}</button></a>
+
+<!-- TODO: add screenshot example -->
+
+#### System WebViews
+
+`ASWebAuthenticationSession` is the System WebView (SWV) on macOS for authentication flows. All web platform features that are available in Safari, including WebAuthn, are available in a `ASWebAuthenticationSession` instance.
+
+Sites loaded in `ASWebAuthenticationSession` are isolated from the calling app and run in the context of the top level site, just like in a full browser. This means that sign in flows on third party domains, such as a federated identity provider, can use passkeys for signing in.
+
+<a href="https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession" target="_blank"><button type="button" class="btn btn-light">ASWebAuthenticationSession docs @ Apple Developer {{< icon-external-link size=24 >}}</button></a>
+
+<!-- TODO: add screenshot example -->
+
 ### User Verification Behavior
 
 On macOS, the user must set up a local system password. Enabling iCloud Keychain and setting up Touch ID are optional.


### PR DESCRIPTION
Changes:

- Adds WebVew reference sections to Android, iOS/iPadOS, and macOS pages
- Links reference pages to DSM via footnotes
- Change Ubuntu passkeys support to say Browser Extensions
- Change Ubuntu autofill UI to say Browser Extensions
- Makes Native Apps section a top level instead of collapsible
- Tweaks Advanced Capabilities collapsible section styling to make more prominent

Resolves #374 #373 #372 #367 