### PR TITLE
update bitwarden user-verification support

### DIFF
--- a/content/docs/reference/known-issues.md
+++ b/content/docs/reference/known-issues.md
@@ -21,7 +21,7 @@ The following list of passkey providers have not implemented [User Verification]
 | ------------ | ---------------- | ----------------------------- | ------------------------ |
 | 1Password    | Extension        | ❌ Handles request without UV | ❌ Always replies `True` |
 | 1Password    | Native           | ✅ Performs UV                | ✅ UV flag accurate      |
-| Bitwarden    | Extension        | ❌ Handles request without UV | ❌ Always replies `True` |
+| Bitwarden    | Extension        | ✅ Performs UV                | ✅ UV flag accurate      |
 | KeepassXC    | Extension        | ❌ Handles request without UV | ❌ Always replies `True` |
 | Proton Pass  | Extension        | ❌ Handles request without UV | ❌ Always replies `True` |
 | Proton Pass  | Native           | ❌ Handles request without UV | ❌ Always replies `True` |


### PR DESCRIPTION
The Bitwarden extension supports the `userVerification` flag since version [v2024.6.0](https://github.com/bitwarden/clients/releases/tag/browser-v2024.6.0). I tested it in Librewolf (Firefox Fork) on Linux and can confirm it working correctly on my machine.

![2024-07-15_13-21-46](https://github.com/user-attachments/assets/a87e8fad-1242-4d29-bfc0-97aeb9b7e413)
![2024-07-15_13-59-12](https://github.com/user-attachments/assets/ae3a20c7-5863-4486-a90e-c839f16dc76a)

When `userVerification` is discouraged, it will not prompt for the PIN, when it is preferred or required, a PIN prompt is displayed before the passkey is created. Same for the authentication flow.

Please let me know if I should add a note, that it only works from version `v2024.6.0` onwards.