### PR TITLE
Fix license href

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -19,7 +19,7 @@
     fixed = true
 
 [footer]
-    license = '<a href="about/#copyright-and-attributions">CC BY-NC-ND 4.0</a>'
+    license = '<a href="/about/#copyright-and-attributions">CC BY-NC-ND 4.0</a>'
     description = 'This site is brought to you by members of the <a href="https://www.w3.org/community/webauthn-adoption/" target="_blank">W3C WebAuthn Community Adoption Group</a> and the <a href="https://fidoalliance.org/" target="_blank">FIDO Alliance.</a>'
 
 [favicon]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - 📝 Use descriptive commit messages.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a passkeys.dev maintainer before any CI builds will run.
-->

## What type of PR is this? (check all applicable)

- [x] Minor content update (spelling, grammar)
- [ ] Substantive content update (changes meaning)
- [ ] Net new content
- [ ] Reference content update (platforms, device support, etc)
- [ ] Core platform updates (Hugo / Hinode / Cloudflare)
- [ ] Administrivia / chores

## Description, Motivation, and Context
When the user is in the /about page, the license link in the footer returns a 404 because there isn't a preceding slash in the relative URL. It's now added in this commit.

<!--- Describe your changes in detail. Why is this change required? What problem does it solve? -->

## Related Issues

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue # N/A
- Closes # N/A
