### PR TITLE
Add Swift WebAuthn library to list of libraries

### DIFF
--- a/content/en/docs/tools-libraries/libraries.md
+++ b/content/en/docs/tools-libraries/libraries.md
@@ -94,3 +94,7 @@ The ["Awesome WebAuthn"](https://github.com/herrjemand/awesome-webauthn) GitHub 
 - [webauthn-ruby](https://github.com/cedarcode/webauthn-ruby) (Cedarcode)
 - [devise-passkeys](https://github.com/ruby-passkeys/devise-passkeys) (Ruby Passkeys, wrapper around `webauthn-ruby`)
 - [warden-webauthn](https://github.com/ruby-passkeys/warden-webauthn) (Ruby Passkeys, wrapper around `webauthn-ruby`)
+
+### Swift
+
+- [Swift WebAuthn](https://github.com/swift-server/swift-webauthn) ([Swift Server Workgroup](https://www.swift.org/sswg/))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Minor content update (spelling, grammar)
- [ ] Substantive content update (changes meaning)
- [ ] Net new content
- [x] Reference content update (platforms, device support, etc)
- [ ] Core platform updates (Hugo / Hinode / Cloudflare)
- [ ] Administrivia / chores

## Description, Motivation, and Context

Adds the Swift WebAuthn library to the list of libraries that support passkeys