### PR TITLE
Fix typo in 'Conditional Create' reference

### DIFF
--- a/content/en/docs/reference/terms/index.md
+++ b/content/en/docs/reference/terms/index.md
@@ -78,7 +78,7 @@ See [_Autofill UI_](#autofill-ui)
 
 ## Conditional Create
 
-A WebAuthn capability which allows a Relying Party to request the creation of a passkey after a successful sign in user another credential from their credential manager, such as a password.
+A WebAuthn capability which allows a Relying Party to request the creation of a passkey after a successful sign in using another credential from their credential manager, such as a password.
 
 Note:
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Minor content update (spelling, grammar)
- [ ] Substantive content update (changes meaning)
- [ ] Net new content
- [ ] Reference content update (platforms, device support, etc)
- [ ] Core platform updates (Hugo / Hinode / Cloudflare)
- [ ] Administrivia / chores

## Description, Motivation, and Context

I had to read this sentence several times, but I think it is a typo and this PR corrects that. Feel free to close if not, although maybe nice to then change it so that it is easier to read.

I read this as (emphasis mine):

> A WebAuthn capability which allows a Relying Party to request the creation of a passkey **after a successful sign in <del>user</del><ins>using</ins> another credential** from their credential manager, such as a password.
