### PR TITLE
Add Kotlin WebAuthn library to libraries page

### DIFF
--- a/content/en/docs/tools-libraries/libraries.md
+++ b/content/en/docs/tools-libraries/libraries.md
@@ -70,6 +70,10 @@ context of your project.
 
 - [java-webauthn-server](https://github.com/Yubico/java-webauthn-server) ([Yubico](https://developers.yubico.com/java-webauthn-server/))
 
+### Kotlin
+
+- [webauthn-kotlin-multiplatform](https://github.com/szijpeter/webauthn-kotlin-multiplatform) (Peter Szij)
+
 ## Other FIDO2/WebAuthn libraries
 
 The ["Awesome WebAuthn"](https://github.com/herrjemand/awesome-webauthn) GitHub repo is also regularly updated with libraries from the community.


### PR DESCRIPTION
This adds `webauthn-kotlin-multiplatform` under the "Updated for passkeys" section as a Kotlin option.

Why it seems like a fit:
- open-source WebAuthn/passkey library
- Kotlin Multiplatform with published artifacts
- server-side WebAuthn support plus Android/iOS client support
- actively maintained and recently released publicly

Repo: https://github.com/szijpeter/webauthn-kotlin-multiplatform